### PR TITLE
Add-context-input-to-all-widget

### DIFF
--- a/src/app/interfaces/widget.interface.ts
+++ b/src/app/interfaces/widget.interface.ts
@@ -4,6 +4,9 @@ export interface WidgetComponent {
   // Generic attributes object that all widgets can use
   attrs?: Record<string, any>;
   
+  // Optional shared context passed from ViewRenderer/AtomicRenderer
+  context?: any;
+  
   // Content host for nested components (optional)
   contentHost?: ViewContainerRef;
   

--- a/src/app/view-renderer/view-renderer.component.ts
+++ b/src/app/view-renderer/view-renderer.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, SimpleChanges, ViewChild, ViewContainerRef } from '@angular/core'
+import { Component, Input, OnChanges, SimpleChanges, ViewChild, ViewContainerRef, Injector, EnvironmentInjector } from '@angular/core'
 import { CommonModule } from '@angular/common'
 import { AtomicRendererService } from '../services/atomic-renderer.service'
 
@@ -17,6 +17,9 @@ import { AtomicRendererService } from '../services/atomic-renderer.service'
 })
 export class ViewRendererComponent implements OnChanges {
   @Input() xml: string = ''
+  @Input() context?: any
+  @Input() injector?: Injector
+  @Input() environmentInjector?: EnvironmentInjector
 
   @ViewChild('host', { read: ViewContainerRef, static: true })
   private host!: ViewContainerRef
@@ -24,8 +27,12 @@ export class ViewRendererComponent implements OnChanges {
   constructor(private readonly atomicRenderer: AtomicRendererService) {}
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes['xml']) {
-      this.atomicRenderer.renderXmlContent(this.xml, this.host)
+    if (changes['xml'] || changes['context'] || changes['injector'] || changes['environmentInjector']) {
+      this.atomicRenderer.renderXmlContent(this.xml, this.host, {
+        injector: this.injector,
+        environmentInjector: this.environmentInjector,
+        context: this.context
+      })
     }
   }
 }

--- a/src/app/widgets/button.component.ts
+++ b/src/app/widgets/button.component.ts
@@ -27,6 +27,7 @@ export class ButtonComponent implements WidgetComponent {
   @Input() label: string = 'دکمه';
   @Input() color?: string;
   @Input() attrs?: Record<string, any>;
+  @Input() context?: any;
   @Output() clicked = new EventEmitter<void>();
 
   @ViewChild('contentHost', { read: ViewContainerRef, static: true })

--- a/src/app/widgets/card.component.ts
+++ b/src/app/widgets/card.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, ViewChild, ViewContainerRef, OnChanges, SimpleChanges, AfterViewInit, inject } from '@angular/core';
+import { Component, Input, ViewChild, ViewContainerRef, OnChanges, SimpleChanges, AfterViewInit, inject, Injector } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { WidgetComponent } from '../interfaces/widget.interface';
 import { AtomicRendererService } from '../services/atomic-renderer.service';
@@ -15,8 +15,10 @@ export class CardComponent implements WidgetComponent, OnChanges, AfterViewInit 
   @Input() attrs?: Record<string, any>;
   @Input() isAtomic?: boolean;
   @Input() xmlContent?: string;
+  @Input() context?: any;
 
   private atomicRenderer = inject(AtomicRendererService);
+  private injector = inject(Injector);
   private viewInitialized = false;
 
   @ViewChild('contentHost', { read: ViewContainerRef, static: true })
@@ -45,7 +47,10 @@ export class CardComponent implements WidgetComponent, OnChanges, AfterViewInit 
   private renderAtomicContent(): void {
     if (this.contentHost && this.xmlContent) {
       this.contentHost.clear();
-      this.atomicRenderer.renderXmlContent(this.xmlContent, this.contentHost);
+      this.atomicRenderer.renderXmlContent(this.xmlContent, this.contentHost, {
+        injector: this.injector,
+        context: this.context
+      });
     }
   }
 }

--- a/src/app/widgets/label.component.ts
+++ b/src/app/widgets/label.component.ts
@@ -18,6 +18,7 @@ export class LabelComponent implements WidgetComponent {
   @Input() text: string = '';
   @Input() color?: string;
   @Input() attrs?: Record<string, any>;
+  @Input() context?: any;
 
   @ViewChild('contentHost', { read: ViewContainerRef, static: true })
   public contentHost!: ViewContainerRef;

--- a/src/app/widgets/lazy-render.component.ts
+++ b/src/app/widgets/lazy-render.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, ViewChild, ViewContainerRef, AfterViewInit, ElementRef, OnDestroy, inject } from '@angular/core';
+import { Component, Input, ViewChild, ViewContainerRef, AfterViewInit, ElementRef, OnDestroy, inject, Injector, EnvironmentInjector } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AtomicRendererService } from '../services/atomic-renderer.service';
 
@@ -25,12 +25,16 @@ import { AtomicRendererService } from '../services/atomic-renderer.service';
 export class LazyRenderComponent implements AfterViewInit, OnDestroy {
   @Input() xml?: string;
   @Input() delayMs: number = 2000; // default 2s delay after entering viewport
+  @Input() context?: any;
+  @Input() injector?: Injector;
+  @Input() environmentInjector?: EnvironmentInjector;
 
   @ViewChild('host', { read: ViewContainerRef, static: true })
   private host!: ViewContainerRef;
 
   private el = inject(ElementRef<HTMLElement>);
   private atomic = inject(AtomicRendererService);
+  private selfInjector = inject(Injector);
   private io?: IntersectionObserver;
   private timeoutId: any;
   rendered = false;
@@ -52,7 +56,11 @@ export class LazyRenderComponent implements AfterViewInit, OnDestroy {
         this.timeoutId = setTimeout(() => {
           // Render and clean up
           this.host.clear();
-          this.atomic.renderXmlContent(this.xml!, this.host);
+          this.atomic.renderXmlContent(this.xml!, this.host, {
+            injector: this.injector ?? this.selfInjector,
+            environmentInjector: this.environmentInjector,
+            context: this.context
+          });
           this.rendered = true;
           this.cleanup();
         }, this.delayMs);

--- a/src/app/widgets/tab.component.ts
+++ b/src/app/widgets/tab.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, ViewChild, ViewContainerRef, OnInit, OnDestroy, OnChanges, SimpleChanges, AfterViewInit, inject } from '@angular/core';
+import { Component, Input, ViewChild, ViewContainerRef, OnInit, OnDestroy, OnChanges, SimpleChanges, AfterViewInit, inject, Injector } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TabsComponent } from './tabs.component';
 import { WidgetComponent } from '../interfaces/widget.interface';
@@ -17,12 +17,14 @@ export class TabComponent implements OnInit, OnDestroy, OnChanges, AfterViewInit
   @Input() attrs?: Record<string, any>;
   @Input() isAtomic?: boolean;
   @Input() xmlContent?: string;
+  @Input() context?: any;
 
   @ViewChild('contentHost', { read: ViewContainerRef, static: true })
   public contentHost!: ViewContainerRef;
 
   private parentTabs = inject(TabsComponent, { optional: true });
   private atomicRenderer = inject(AtomicRendererService);
+  private injector = inject(Injector);
   private viewInitialized = false;
 
   ngOnInit(): void {
@@ -49,7 +51,10 @@ export class TabComponent implements OnInit, OnDestroy, OnChanges, AfterViewInit
   private renderAtomicContent(): void {
     if (this.contentHost && this.xmlContent) {
       this.contentHost.clear();
-      this.atomicRenderer.renderXmlContent(this.xmlContent, this.contentHost);
+      this.atomicRenderer.renderXmlContent(this.xmlContent, this.contentHost, {
+        injector: this.injector,
+        context: this.context
+      });
     }
   }
 


### PR DESCRIPTION
Add context input to all widget components to enable shared data passing. Update AtomicRendererService to handle context propagation through component hierarchy.